### PR TITLE
darwin: use absolute path to stat and diskutil

### DIFF
--- a/device_darwin.go
+++ b/device_darwin.go
@@ -29,12 +29,12 @@ func discoverDeviceName(logger sglog.Logger, filePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to resolve %s: %w", filePath, err)
 	}
-	stat, err := exec.Command("stat", "-f", "%Sd", filePath).Output()
+	stat, err := exec.Command("/usr/bin/stat", "-f", "%Sd", filePath).Output()
 	if err != nil {
 		return "", fmt.Errorf("unable to stat %s: %w", filePath, err)
 	}
 
-	diskinfo, err := exec.Command("diskutil", "info", strings.TrimSpace(string(stat))).CombinedOutput()
+	diskinfo, err := exec.Command("/usr/sbin/diskutil", "info", strings.TrimSpace(string(stat))).CombinedOutput()
 	if err != nil {
 		// log the output from `diskutil` instead of including it in the error message because it may be multiline
 		logger.Error(fmt.Sprintf("unable to get disk info on %s. Output is (%s)", string(stat), string(diskinfo)))


### PR DESCRIPTION
We want to use the system installed versions of these programs. For example if you have coreutils installed, then your version of "stat" will work differently to the darwin stat. This is the case for me and I always get a warning on darwin at startup.

Additionally after some googling of darwin's OSS, they seem to always hardcode the absolute path.

Test Plan: go test and running zoekt pointed at this version of mountinfo.