### PR TITLE
fix: suppress warnings for virtual/pseudo filesystems

### DIFF
--- a/device_linux.go
+++ b/device_linux.go
@@ -5,11 +5,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/moby/sys/mountinfo"
 	sglog "github.com/sourcegraph/log"
 )
+
+// isVirtualFilesystem determines if a filesystem is virtual/pseudo based on
+// major number and filesystem type
+func isVirtualFilesystem(deviceNumber string) bool {
+	parts := strings.Split(deviceNumber, ":")
+	if len(parts) != 2 {
+		return false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+
+	// Major number 0 indicates a virtual filesystem
+	return major == 0
+}
 
 // defined as a variable so that it can be redefined by test routines
 var findSysfsMountpoint = func() (mountpoint string, err error) {
@@ -132,6 +150,10 @@ func discoverDeviceName(logger sglog.Logger, filePath string) (string, error) {
 		"discovered device number",
 		sglog.String("deviceNumber", deviceNumber),
 	)
+
+	if isVirtualFilesystem(deviceNumber) {
+		return "", fmt.Errorf("unsupported device number: %w", &virtualFilesystemError{DeviceNumber: deviceNumber})
+	}
 
 	devicePath, err := discoverSysfsDevicePath(sysfsMountPoint, deviceNumber)
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMd
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -59,7 +57,6 @@ github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
@@ -114,12 +111,9 @@ github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=
 github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0GqwkjqxNd0u65g=
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
-github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=
@@ -168,9 +162,7 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
-github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
@@ -208,10 +200,6 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/sourcegraph/log v0.0.0-20230918165208-4a174e4ec4cf h1:eALn0yz3ljezZVueXObvk0hHBr3Qsox+L78//9qps+M=
-github.com/sourcegraph/log v0.0.0-20230918165208-4a174e4ec4cf/go.mod h1:IDp09QkoqS8Z3CyN2RW6vXjgABkNpDbyjLIHNQwQ8P8=
-github.com/sourcegraph/log v0.0.0-20231018072732-c9c6af5e5ade h1:EpakpjinOPDoLLUXfAzdrKc21teqkWJ3xLLTOINb3m8=
-github.com/sourcegraph/log v0.0.0-20231018072732-c9c6af5e5ade/go.mod h1:IDp09QkoqS8Z3CyN2RW6vXjgABkNpDbyjLIHNQwQ8P8=
 github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb h1:tHKdC+bXxxGJ0cy/R06kg6Z0zqwVGOWMx8uWsIwsaoY=
 github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb/go.mod h1:IDp09QkoqS8Z3CyN2RW6vXjgABkNpDbyjLIHNQwQ8P8=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -377,7 +365,6 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -390,7 +377,6 @@ gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3M
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/info.go
+++ b/info.go
@@ -3,6 +3,9 @@
 package mountinfo
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 	sglog "github.com/sourcegraph/log"
 )
@@ -45,6 +48,16 @@ func NewCollector(logger sglog.Logger, opts CollectorOpts, mounts map[string]str
 
 		device, err := discoverDeviceName(discoveryLogger, filePath)
 		if err != nil {
+			// Check if this is a virtual filesystem - don't warn for those
+			var virtualFsErr *virtualFilesystemError
+			if errors.As(err, &virtualFsErr) {
+				discoveryLogger.Debug("skipping metric registration for virtual filesystem",
+					sglog.String("deviceNumber", virtualFsErr.DeviceNumber),
+				)
+				continue
+			}
+
+			// For block devices that failed, log as warning
 			discoveryLogger.Warn("skipping metric registration",
 				sglog.String("reason", "failed to discover device name"),
 				sglog.Error(err),
@@ -61,4 +74,14 @@ func NewCollector(logger sglog.Logger, opts CollectorOpts, mounts map[string]str
 	}
 
 	return metric
+}
+
+// virtualFilesystemError is returned when a filesystem is virtual/pseudo
+// and doesn't have a block device
+type virtualFilesystemError struct {
+	DeviceNumber string
+}
+
+func (e *virtualFilesystemError) Error() string {
+	return fmt.Sprintf("virtual filesystem (device %s)", e.DeviceNumber)
 }

--- a/info_linux_test.go
+++ b/info_linux_test.go
@@ -3,15 +3,15 @@
 package mountinfo
 
 import (
-	"log"
-	"os"
-	"testing"
-
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
+	"log"
+	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
@@ -30,10 +30,88 @@ func Test_DeviceName_SmokeTest(t *testing.T) {
 
 	device, err := discoverDeviceName(logger, filePath)
 	if err != nil {
+		// Check if this is a virtual filesystem - that's acceptable
+		var virtualFsErr *virtualFilesystemError
+		if errors.As(err, &virtualFsErr) {
+			t.Logf("skipping test: current working directory is on a virtual filesystem (device %s)", virtualFsErr.DeviceNumber)
+			return
+		}
 		t.Fatalf("Unable to find device name for path %q: %s", filePath, err)
 	}
 
 	t.Logf("discovered device name %q for path %q", device, filePath)
+}
+
+func Test_isVirtualFilesystem(t *testing.T) {
+	tests := []struct {
+		name         string
+		deviceNumber string
+		wantVirtual  bool
+		wantErr      bool
+	}{
+		{
+			name:         "virtual filesystem - tmpfs",
+			deviceNumber: "0:25",
+			wantVirtual:  true,
+		},
+		{
+			name:         "virtual filesystem - proc",
+			deviceNumber: "0:5",
+			wantVirtual:  true,
+		},
+		{
+			name:         "block device - vda1",
+			deviceNumber: "254:1",
+			wantVirtual:  false,
+		},
+		{
+			name:         "block device - nvme",
+			deviceNumber: "259:0",
+			wantVirtual:  false,
+		},
+		{
+			name:         "invalid format - missing colon",
+			deviceNumber: "254",
+			wantVirtual:  false,
+		},
+		{
+			name:         "invalid format - non-numeric major",
+			deviceNumber: "abc:1",
+			wantVirtual:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isVirtual := isVirtualFilesystem(tt.deviceNumber)
+			if isVirtual != tt.wantVirtual {
+				t.Errorf("isVirtualFilesystem() = %v, want %v", isVirtual, tt.wantVirtual)
+			}
+		})
+	}
+}
+
+func Test_DeviceName_VirtualFilesystem(t *testing.T) {
+	logger := logtest.Scoped(t)
+
+	// Mock a virtual filesystem (major:minor = 0:x)
+	getDeviceNumber = func(filePath string) (deviceNumber string, err error) {
+		return "0:25", nil // tmpfs typically uses 0:X
+	}
+
+	_, err := discoverDeviceName(logger, "/fake/path")
+	if err == nil {
+		t.Fatal("expected error for virtual filesystem, got nil")
+	}
+
+	var virtualFsErr *virtualFilesystemError
+	if !errors.As(err, &virtualFsErr) {
+		t.Fatalf("expected VirtualFilesystemError, got %T: %v", err, err)
+	}
+
+	if virtualFsErr.DeviceNumber != "0:25" {
+		t.Errorf("expected device number 0:25, got %s", virtualFsErr.DeviceNumber)
+	}
 }
 
 func Test_DeviceName_Snapshots(t *testing.T) {


### PR DESCRIPTION
Previously, the mountinfo library generated WARN-level logs for virtual and pseudo filesystems (tmpfs, overlay, btrfs subvolumes, NFS, etc.) that don't have entries in /sys/dev/block/. This was expected behavior since virtual filesystems don't correspond to block devices, but the warnings were confusing and noisy.

In particular I had this log message on my devbox:

```
  WARN metricsRegistration.mountPointInfo.deviceNameDiscovery mountinfo@v0.0.0-20240201124957-b314c0befab1/info.go:48 skipping metric registration {"mountName": "indexDir", "mountFilePath": "/home/keegan/.sourcegraph/zoekt/index-0", "reason": "failed to discover device name", "error": "discovering device path: discoverSysfsDevicePath: failed to evaluate sysfs symlink \"/sys/dev/block/0:34\": lstat /sys/dev/block/0:34: no such file or directory"}
```

Test Plan: go test works on my machine (previously failed instead of skipping on the smoke test). Additionally pointing Sourcegraph to this repository removes the log spam in dev for me.