### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.25"
+          go-version: "1.26.4"
 
       - name: Test
         run: go test -v -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/mountinfo
 
-go 1.25
+go 1.26.4
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/info_linux_test.go
+++ b/info_linux_test.go
@@ -193,7 +193,6 @@ func Test_DeviceName_Snapshots(t *testing.T) {
 			expectedDeviceName: "dm-0",
 		},
 	} {
-		test := test
 
 		t.Run(t.Name(), func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)